### PR TITLE
Fix two issues found by cppcheck/sonar

### DIFF
--- a/scalerApp/src/drvScaler974.cpp
+++ b/scalerApp/src/drvScaler974.cpp
@@ -164,7 +164,7 @@ asynStatus Scaler974::writeInt32(asynUser *pasynUser, epicsInt32 value)
     else if(function==this->scalerPreset)
     {
         int m,n;
-        char newstr[20];
+        char newstr[25];
 
         n=(int)log10(double(value));
         m=(int)(value/pow(10.0,n));

--- a/scalerApp/src/scalerRecord.c
+++ b/scalerApp/src/scalerRecord.c
@@ -128,12 +128,8 @@ Modification Log:
 #define USER_STATE_REQSTART 2
 #define USER_STATE_COUNTING 3
 
-#ifdef NODEBUG
-#define Debug(l,FMT,V) ;
-#else
 #define Debug(level)  if(level<=scalerRecordDebug) \
 		{printf("%s(%d):",__FILE__,__LINE__); printf(
-#endif
 
 volatile int scalerRecordDebug = 0;
 volatile int scaler_wait_time = 10;


### PR DESCRIPTION
This PR fixes two issues that keeps std (the original module of the code) from passing ITER's quality gates for non-essential software.